### PR TITLE
소셜로그인 성공/실패 여부에따른 URL변경

### DIFF
--- a/src/main/java/net/detalk/api/support/security/OAuthFailHandler.java
+++ b/src/main/java/net/detalk/api/support/security/OAuthFailHandler.java
@@ -24,7 +24,7 @@ public class OAuthFailHandler implements AuthenticationFailureHandler {
     @Override
     public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response, AuthenticationException exception)
         throws ServletException, IOException {
-        String url = appProperties.getBaseUrl() + "?error=oauth";
+        String url = appProperties.getBaseUrl() + "?oauth=fail";
         redirectStrategy.sendRedirect(request, response, url);
     }
 }

--- a/src/main/java/net/detalk/api/support/security/SessionOAuthSuccessHandler.java
+++ b/src/main/java/net/detalk/api/support/security/SessionOAuthSuccessHandler.java
@@ -40,8 +40,11 @@ public class SessionOAuthSuccessHandler implements AuthenticationSuccessHandler 
             SecurityContextHolder.getContext().setAuthentication(securityAuthentication);
         } else {
             log.error("[onAuthenticationSuccess] 시큐리티 컨텍스트 홀더 등록 실패");
+            String url = appProperties.getBaseUrl() + "?oauth=fail";
+            redirectStrategy.sendRedirect(request, response, url);
+            return;
         }
-
-        redirectStrategy.sendRedirect(request, response, appProperties.getBaseUrl());
+        String url = appProperties.getBaseUrl() + "?oauth=success";
+        redirectStrategy.sendRedirect(request, response, url);
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
	- OAuth 인증 실패 시 리다이렉션 URL의 쿼리 파라미터를 `?error=oauth`에서 `?oauth=fail`로 변경하였습니다.
  
- **기능 개선**
	- OAuth 인증 성공 및 실패 처리 로직을 개선하여 성공 시 `?oauth=success`로 리다이렉션되도록 하였습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->