### PR TITLE
회원 프로필.member_id 컬럼 인덱스 추가

### DIFF
--- a/src/main/java/net/detalk/api/repository/ProductPostRepository.java
+++ b/src/main/java/net/detalk/api/repository/ProductPostRepository.java
@@ -72,7 +72,7 @@ public class ProductPostRepository {
                 PRODUCT_POST_SNAPSHOT.TITLE,
                 PRODUCT_POST_SNAPSHOT.DESCRIPTION,
                 PRICING_PLAN.NAME.as("pricingPlan"),
-                DSL.arrayAgg(TAG.NAME).as("tags"),
+                DSL.arrayAggDistinct(TAG.NAME).as("tags"),
                 PRODUCT_POST.RECOMMEND_COUNT.as("recommendCount"),
                 PRODUCT_POST_SNAPSHOT.ID.as("snapshotId"),
                 DSL.arrayAggDistinct(PRODUCT_LINK.URL).as("urls")
@@ -209,7 +209,7 @@ public class ProductPostRepository {
                 PRODUCT_POST_SNAPSHOT.TITLE,
                 PRODUCT_POST_SNAPSHOT.DESCRIPTION,
                 PRICING_PLAN.NAME.as("pricingPlan"),
-                DSL.arrayAgg(TAG.NAME).as("tags"),
+                DSL.arrayAggDistinct(TAG.NAME).as("tags"),
                 PRODUCT_POST.RECOMMEND_COUNT.as("recommendCount"),
                 PRODUCT_POST_SNAPSHOT.ID.as("snapshotId"),
                 DSL.arrayAggDistinct(PRODUCT_LINK.URL).as("urls")
@@ -278,7 +278,7 @@ public class ProductPostRepository {
                 PRODUCT_POST_SNAPSHOT.TITLE,
                 PRODUCT_POST_SNAPSHOT.DESCRIPTION,
                 PRICING_PLAN.NAME.as("pricingPlan"),
-                DSL.arrayAgg(TAG.NAME).as("tags"),
+                DSL.arrayAggDistinct(TAG.NAME).as("tags"),
                 PRODUCT_POST.RECOMMEND_COUNT.as("recommendCount"),
                 PRODUCT_POST_SNAPSHOT.ID.as("snapshotId"),
                 DSL.arrayAggDistinct(PRODUCT_LINK.URL).as("urls")
@@ -346,7 +346,7 @@ public class ProductPostRepository {
                 PRODUCT_POST_SNAPSHOT.TITLE,
                 PRODUCT_POST_SNAPSHOT.DESCRIPTION,
                 PRICING_PLAN.NAME.as("pricingPlan"),
-                DSL.arrayAgg(TAG.NAME).as("tags"),
+                DSL.arrayAggDistinct(TAG.NAME).as("tags"),
                 PRODUCT_POST.RECOMMEND_COUNT.as("recommendCount"),
                 PRODUCT_POST_SNAPSHOT.ID.as("snapshotId"),
                 DSL.arrayAggDistinct(PRODUCT_LINK.URL).as("urls"),

--- a/src/main/resources/db/migration/V0.0.2__addIndex.sql
+++ b/src/main/resources/db/migration/V0.0.2__addIndex.sql
@@ -1,0 +1,1 @@
+CREATE INDEX "idx_member_profile_member_id" ON "member_profile" ("member_id");


### PR DESCRIPTION
### 1. 게시글 상세조회 - **ProductPostRepository.findDetailsById()**  인덱스 적용 전/후 쿼리 실행 계획 결과

적용한 인덱스
```sql
CREATE INDEX "idx_member_profile_member_id" ON "member_profile" ("member_id");
```

- 전
```sql
Seq Scan on member_profile  (cost=0.00..137.00 rows=5000 width=171) (actual time=0.015..1.164 rows=5000 loops=1)
Execution Time: 3.126 ms
```

- 후
```sql
Index Scan using idx_member_profile_member_id on member_profile  (cost=0.28..8.30 rows=1 width=171) (actual time=0.022..0.023 rows=1 loops=1)
Execution Time: 0.648 ms
```
- 비교
``` sql
3.126 -> 0.648 (4.8배 향상)
```

---
### 2.게시글 목록 조회 - **ProductPostRepository.findProductPosts()** 인덱스 적용 전/후 쿼리 실행 계획 결과

- 전

```sql
Seq Scan on member_profile  (cost=0.00..137.00 rows=5000 width=171) (actual time=0.004..0.381 rows=5000 loops=1)
Execution Time: 65.788 ms
```

- 후
``` 
Seq Scan on member_profile  (cost=0.00..137.00 rows=5000 width=171) (actual time=0.004..0.508 rows=5000 loops=1)
```

**문제 발생, 인덱스를 걸었는데 풀스캔 한다.**
원인
- 쿼리에서 **WHERE "product_post"."id" < 5900** 조건과 **ORDER BY "product_post"."created_at" DESC, "product_post"."id" DESC** 절을 함께 사용
- **product_post.created_at**에 대한 index가 없음. -> created_at와 product_post.id **복합 인덱스를 설정해야 함**
- 주의해야할점으론 where절에서 product_post.id 조건문이 있기 때문에 복합인덱스 순서를 product_post.id부터 해야 함
**복합 인덱스 적용**
```sql
CREATE INDEX "idx_product_post_id_created_at_desc" ON "product_post" ("id" DESC, "created_at" DESC);
```

다음 쿼리문 순서도 변경 해야 함
``` sql
-> .orderBy(PRODUCT_POST.CREATED_AT.desc(), PRODUCT_POST.ID.desc()) [X] 복합 인덱스가 걸려 있어도, 순서가 잘못되어 풀 스캔한다.

-> .orderBy(PRODUCT_POST.ID.desc(), PRODUCT_POST.CREATED_AT.desc()) [O] 
```

- 복합 인덱스 적용후
``` sql
Execution Time: 8.031 ms
```

- 비교
``` sql
65.788ms ->  8.031 ms (약 8배 향상)
```
 