### PR TITLE
예외 메세지 민감한 정보 제거

### DIFF
--- a/src/main/java/net/detalk/api/domain/exception/InvalidPageSizeException.java
+++ b/src/main/java/net/detalk/api/domain/exception/InvalidPageSizeException.java
@@ -5,8 +5,11 @@ import org.springframework.http.HttpStatus;
 
 public class InvalidPageSizeException extends ApiException {
 
+    private static final int MIN_PAGE_SIZE = 1;
+    private static final int MAX_PAGE_SIZE = 20;
+
     public InvalidPageSizeException(int pageSize) {
-        super(String.format("잘못된 페이지 사이즈 요청입니다: [%d], 페이지 사이즈는 1 이상이어야 합니다.", pageSize));
+        super(String.format("잘못된 페이지 크기입니다: %d (허용 범위: %d-%d)", pageSize, MIN_PAGE_SIZE, MAX_PAGE_SIZE));
     }
 
     @Override

--- a/src/main/java/net/detalk/api/domain/exception/MemberNotFoundException.java
+++ b/src/main/java/net/detalk/api/domain/exception/MemberNotFoundException.java
@@ -5,8 +5,8 @@ import org.springframework.http.HttpStatus;
 
 public class MemberNotFoundException extends ApiException {
 
-    public MemberNotFoundException(Long memberId) {
-        super(String.format("회원(ID: %d)을 찾을 수 없습니다.", memberId));
+    public MemberNotFoundException() {
+        super("해당 회원을 찾을 수 없습니다.");
     }
 
     @Override

--- a/src/main/java/net/detalk/api/domain/exception/ProductPostForbiddenException.java
+++ b/src/main/java/net/detalk/api/domain/exception/ProductPostForbiddenException.java
@@ -5,8 +5,8 @@ import org.springframework.http.HttpStatus;
 
 public class ProductPostForbiddenException extends ApiException {
 
-    public ProductPostForbiddenException(Long postId, Long memberId) {
-        super(String.format("작성자와 요청자가 다릅니다. productPostId=%d, memberId=%d", postId, memberId));
+    public ProductPostForbiddenException() {
+        super("제품 게시물 수정 권한이 없습니다.");
     }
 
     @Override

--- a/src/main/java/net/detalk/api/domain/exception/RefreshTokenNotFoundException.java
+++ b/src/main/java/net/detalk/api/domain/exception/RefreshTokenNotFoundException.java
@@ -5,8 +5,8 @@ import org.springframework.http.HttpStatus;
 
 public class RefreshTokenNotFoundException extends ApiException {
 
-    public RefreshTokenNotFoundException(String tokenIdentifier) {
-        super(String.format("리프레시 토큰을 찾을 수 없습니다: %s", tokenIdentifier));
+    public RefreshTokenNotFoundException() {
+        super("존재하지 않는 리프레시 토큰입니다.");
     }
 
     @Override

--- a/src/main/java/net/detalk/api/service/AuthService.java
+++ b/src/main/java/net/detalk/api/service/AuthService.java
@@ -66,7 +66,7 @@ public class AuthService extends DefaultOAuth2UserService {
 
         // member 첫 회원가입 상태여부
         boolean isNewMember = memberRepository.findById(memberExternal.getMemberId())
-            .orElseThrow(() -> new MemberNotFoundException(memberExternal.getMemberId()))
+            .orElseThrow(MemberNotFoundException::new)
             .isNewMember();
 
         // TODO: ADMIN 권한 확인
@@ -162,7 +162,7 @@ public class AuthService extends DefaultOAuth2UserService {
         AuthRefreshToken authRefreshToken = authRefreshTokenRepository.findByToken(verifiedRefreshToken.getValue())
             .orElseThrow(() -> {
                 log.error("[refresh] 서버에 존재하지 않는 토큰 : {}", originalRefreshToken);
-                return new RefreshTokenNotFoundException(originalRefreshToken);
+                return new RefreshTokenNotFoundException();
             });
 
         Long memberId = authRefreshToken.getMemberId();
@@ -194,7 +194,7 @@ public class AuthService extends DefaultOAuth2UserService {
         AuthRefreshToken authRefreshToken = authRefreshTokenRepository.findByToken(verifiedRefreshToken.getValue())
             .orElseThrow(() -> {
                 log.error("[signOut] 서버에 존재하지 않는 토큰 : {}", refreshToken);
-                return new RefreshTokenNotFoundException(refreshToken);
+                return new RefreshTokenNotFoundException();
             });
         authRefreshToken.revoked(timeHolder);
         authRefreshTokenRepository.update(authRefreshToken);

--- a/src/main/java/net/detalk/api/service/MemberService.java
+++ b/src/main/java/net/detalk/api/service/MemberService.java
@@ -14,9 +14,7 @@ import net.detalk.api.domain.exception.UserHandleDuplicatedException;
 import net.detalk.api.repository.MemberProfileRepository;
 import net.detalk.api.repository.MemberRepository;
 import net.detalk.api.support.TimeHolder;
-import net.detalk.api.support.error.ApiException;
 import net.detalk.api.support.error.InvalidStateException;
-import net.detalk.api.support.error.ErrorCode;
 import org.springframework.stereotype.Service;
 
 @Slf4j
@@ -31,7 +29,7 @@ public class MemberService {
     public MemberDetail me(Long memberId) {
         Member member = memberRepository.findById(memberId).orElseThrow(() -> {
             log.error("[me] 회원 ID {}는 존재하지 않는 회원입니다", memberId);
-            return new MemberNotFoundException(memberId);
+            return new MemberNotFoundException();
         });
 
         if (member.isPendingExternalMember()) {
@@ -55,7 +53,7 @@ public class MemberService {
 
         Member member = memberRepository.findById(memberId).orElseThrow(() -> {
             log.error("[registerProfile] 회원 ID {}는 존재하지 않는 회원입니다", memberId);
-            return new MemberNotFoundException(memberId);
+            return new MemberNotFoundException();
         });
 
         if (!member.isPendingExternalMember()) {

--- a/src/main/java/net/detalk/api/service/ProductPostService.java
+++ b/src/main/java/net/detalk/api/service/ProductPostService.java
@@ -250,7 +250,7 @@ public class ProductPostService {
         // 작성자 검증
         if (!productPost.isAuthor(memberId)) {
             log.error("[update] 작성자와 요청자가 다릅니다 memberId={}", memberId);
-            throw new ProductPostForbiddenException(postId, memberId);
+            throw new ProductPostForbiddenException();
         }
 
         // 2. 제품 조회 또는 재사용
@@ -380,7 +380,7 @@ public class ProductPostService {
      * 페이지 사이즈 검증 1이하라면 에러
      * @param pageSize 검증할 사이즈
      */
-    public void validatePageSize(int pageSize) {
+    private void validatePageSize(int pageSize) {
         if (pageSize < 1) {
             log.warn("잘못된 페이지 사이즈 요청입니다={}", pageSize);
             throw new InvalidPageSizeException(pageSize);

--- a/src/main/java/net/detalk/api/support/error/ApiException.java
+++ b/src/main/java/net/detalk/api/support/error/ApiException.java
@@ -1,13 +1,16 @@
 package net.detalk.api.support.error;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.Map;
 import lombok.Getter;
 import lombok.NonNull;
-import org.flywaydb.core.internal.util.JsonUtils;
 import org.springframework.http.HttpStatus;
 
 @Getter
 public abstract class ApiException extends RuntimeException {
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
     protected ApiException() {
     }
@@ -25,10 +28,19 @@ public abstract class ApiException extends RuntimeException {
     }
 
     protected ApiException(@NonNull Map<String, Object> messageFields) {
-        super(JsonUtils.toJson(messageFields));
+        super(convertToJson(messageFields));
     }
 
-    protected ApiException(String message, Throwable cause, boolean enableSuppression, boolean writableStackTrace) {
+    private static String convertToJson(Map<String, Object> messageFields) {
+        try {
+            return OBJECT_MAPPER.writeValueAsString(messageFields);
+        } catch (JsonProcessingException e) {
+            throw new JsonConversionException("Failed to convert message fields to JSON", e);
+        }
+    }
+
+    protected ApiException(String message, Throwable cause, boolean enableSuppression,
+        boolean writableStackTrace) {
         super(message, cause, enableSuppression, writableStackTrace);
     }
 

--- a/src/main/java/net/detalk/api/support/error/JsonConversionException.java
+++ b/src/main/java/net/detalk/api/support/error/JsonConversionException.java
@@ -1,0 +1,25 @@
+package net.detalk.api.support.error;
+
+import org.springframework.http.HttpStatus;
+
+public class JsonConversionException extends ApiException {
+
+    public JsonConversionException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    @Override
+    public HttpStatus getHttpStatus() {
+        return HttpStatus.INTERNAL_SERVER_ERROR;
+    }
+
+    @Override
+    public String getErrorCode() {
+        return "json_conversion_failed";
+    }
+
+    @Override
+    public boolean isNecessaryToLog() {
+        return true;
+    }
+}

--- a/src/test/java/net/detalk/api/service/ProductPostServiceTest.java
+++ b/src/test/java/net/detalk/api/service/ProductPostServiceTest.java
@@ -418,8 +418,8 @@ class ProductPostServiceTest {
             () -> productPostService.getProductPosts(pageSizeNegative, nextId));
 
         // then
-        assertThat(exceptionZero.getMessage()).isEqualTo("잘못된 페이지 사이즈 요청입니다: [0], 페이지 사이즈는 1 이상이어야 합니다.");
-        assertThat(exceptionNegative.getMessage()).isEqualTo("잘못된 페이지 사이즈 요청입니다: [-99], 페이지 사이즈는 1 이상이어야 합니다.");
+        assertThat(exceptionZero.getMessage()).isEqualTo("잘못된 페이지 크기입니다: 0 (허용 범위: 1-20)");
+        assertThat(exceptionNegative.getMessage()).isEqualTo("잘못된 페이지 크기입니다: -99 (허용 범위: 1-20)");
 
     }
 
@@ -483,7 +483,7 @@ class ProductPostServiceTest {
             () -> productPostService.getProductPostsByMemberId(memberId, pageSize, nextId));
 
         // then
-        assertThat(exception.getMessage()).isEqualTo("잘못된 페이지 사이즈 요청입니다: [0], 페이지 사이즈는 1 이상이어야 합니다.");
+        assertThat(exception.getMessage()).isEqualTo("잘못된 페이지 크기입니다: 0 (허용 범위: 1-20)");
     }
 
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **예외 처리**
	- 페이지 크기 예외 처리 메시지 개선
	- 일부 예외 생성자 간소화 (멤버, 리프레시 토큰, 제품 게시물 예외)
	- 새로운 JSON 변환 예외 클래스 추가

- **서비스 변경**
	- 일부 메서드의 접근 제어자 변경 (예: `validatePageSize` 메서드를 `private`로 수정)

- **테스트**
	- 페이지 크기 관련 테스트 케이스 오류 메시지 업데이트

<!-- end of auto-generated comment: release notes by coderabbit.ai -->