### PR TITLE
중복된 게시글 URL 저장 시, URL저장 안되는 버그 수정

### DIFF
--- a/src/main/java/net/detalk/api/domain/ProductPostLink.java
+++ b/src/main/java/net/detalk/api/domain/ProductPostLink.java
@@ -1,0 +1,18 @@
+package net.detalk.api.domain;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ProductPostLink {
+
+    private Long postId;
+    private Long linkId;
+
+    public ProductPostLink(Long postId, Long linkId) {
+        this.postId = postId;
+        this.linkId = linkId;
+    }
+
+}

--- a/src/main/java/net/detalk/api/repository/ProductPostLinkRepository.java
+++ b/src/main/java/net/detalk/api/repository/ProductPostLinkRepository.java
@@ -1,0 +1,24 @@
+package net.detalk.api.repository;
+
+import static net.detalk.jooq.tables.JProductPostLink.PRODUCT_POST_LINK;
+
+import lombok.RequiredArgsConstructor;
+import net.detalk.api.domain.ProductPostLink;
+import org.jooq.DSLContext;
+import org.springframework.stereotype.Repository;
+
+@RequiredArgsConstructor
+@Repository
+public class ProductPostLinkRepository {
+
+    private final DSLContext dsl;
+
+    public ProductPostLink save(Long postId, Long linkId) {
+        return dsl.insertInto(PRODUCT_POST_LINK)
+            .set(PRODUCT_POST_LINK.POST_ID, postId)
+            .set(PRODUCT_POST_LINK.LINK_ID, linkId)
+            .returning()
+            .fetchOneInto(ProductPostLink.class);
+    }
+
+}

--- a/src/main/java/net/detalk/api/repository/ProductPostRepository.java
+++ b/src/main/java/net/detalk/api/repository/ProductPostRepository.java
@@ -7,6 +7,7 @@ import static net.detalk.jooq.tables.JProductLink.PRODUCT_LINK;
 import static net.detalk.jooq.tables.JProductMaker.PRODUCT_MAKER;
 import static net.detalk.jooq.tables.JProductPost.PRODUCT_POST;
 import static net.detalk.jooq.tables.JProductPostLastSnapshot.PRODUCT_POST_LAST_SNAPSHOT;
+import static net.detalk.jooq.tables.JProductPostLink.PRODUCT_POST_LINK;
 import static net.detalk.jooq.tables.JProductPostSnapshot.PRODUCT_POST_SNAPSHOT;
 import static net.detalk.jooq.tables.JProductPostSnapshotAttachmentFile.PRODUCT_POST_SNAPSHOT_ATTACHMENT_FILE;
 import static net.detalk.jooq.tables.JProductPostSnapshotTag.PRODUCT_POST_SNAPSHOT_TAG;
@@ -94,8 +95,10 @@ public class ProductPostRepository {
             .on(PRODUCT_MAKER.PRODUCT_ID.eq(PRODUCT_POST.PRODUCT_ID))
             .leftJoin(ATTACHMENT_FILE)
             .on(ATTACHMENT_FILE.ID.eq(MEMBER_PROFILE.AVATAR_ID))
+            .leftJoin(PRODUCT_POST_LINK)
+            .on(PRODUCT_POST_LINK.POST_ID.eq(PRODUCT_POST.ID))
             .leftJoin(PRODUCT_LINK)
-            .on(PRODUCT_LINK.PRODUCT_ID.eq(PRODUCT_POST.PRODUCT_ID))
+            .on(PRODUCT_LINK.ID.eq(PRODUCT_POST_LINK.LINK_ID))
             .where(PRODUCT_POST.ID.eq(id))
             .groupBy(
                 PRODUCT_POST.ID,
@@ -231,8 +234,10 @@ public class ProductPostRepository {
                 .on(PRODUCT_MAKER.PRODUCT_ID.eq(PRODUCT_POST.PRODUCT_ID))
             .leftJoin(ATTACHMENT_FILE)
                 .on(ATTACHMENT_FILE.ID.eq(MEMBER_PROFILE.AVATAR_ID))
+            .leftJoin(PRODUCT_POST_LINK)
+            .on(PRODUCT_POST_LINK.POST_ID.eq(PRODUCT_POST.ID))
             .leftJoin(PRODUCT_LINK)
-                .on(PRODUCT_LINK.PRODUCT_ID.eq(PRODUCT_POST.PRODUCT_ID))
+            .on(PRODUCT_LINK.ID.eq(PRODUCT_POST_LINK.LINK_ID))
             .where(condition)
             .groupBy(
                 PRODUCT_POST.ID,
@@ -300,8 +305,10 @@ public class ProductPostRepository {
             .on(PRODUCT_MAKER.PRODUCT_ID.eq(PRODUCT_POST.PRODUCT_ID))
             .leftJoin(ATTACHMENT_FILE)
             .on(ATTACHMENT_FILE.ID.eq(MEMBER_PROFILE.AVATAR_ID))
+            .leftJoin(PRODUCT_POST_LINK)
+            .on(PRODUCT_POST_LINK.POST_ID.eq(PRODUCT_POST.ID))
             .leftJoin(PRODUCT_LINK)
-            .on(PRODUCT_LINK.PRODUCT_ID.eq(PRODUCT_POST.PRODUCT_ID))
+            .on(PRODUCT_LINK.ID.eq(PRODUCT_POST_LINK.LINK_ID))
             .where(condition)
             .groupBy(
                 PRODUCT_POST.ID,
@@ -373,8 +380,10 @@ public class ProductPostRepository {
             .on(PRODUCT_MAKER.PRODUCT_ID.eq(PRODUCT_POST.PRODUCT_ID))
             .leftJoin(ATTACHMENT_FILE)
             .on(ATTACHMENT_FILE.ID.eq(MEMBER_PROFILE.AVATAR_ID))
+            .leftJoin(PRODUCT_POST_LINK)
+            .on(PRODUCT_POST_LINK.POST_ID.eq(PRODUCT_POST.ID))
             .leftJoin(PRODUCT_LINK)
-            .on(PRODUCT_LINK.PRODUCT_ID.eq(PRODUCT_POST.PRODUCT_ID))
+            .on(PRODUCT_LINK.ID.eq(PRODUCT_POST_LINK.LINK_ID))
             .where(condition)
             .groupBy(
                 PRODUCT_POST.ID,

--- a/src/main/resources/db/migration/V0.0.4__add_product_post_link.sql
+++ b/src/main/resources/db/migration/V0.0.4__add_product_post_link.sql
@@ -1,0 +1,8 @@
+-- 각 게시글이 어떤 링크를 사용했는지 연관관계 맺는 테이블
+CREATE TABLE "product_post_link" (
+    "post_id" BIGINT NOT NULL,
+    "link_id" BIGINT NOT NULL,
+    CONSTRAINT "product_post_link_pkey" PRIMARY KEY ("post_id", "link_id"),
+    CONSTRAINT "product_post_link_post_fk" FOREIGN KEY ("post_id") REFERENCES "product_post"("id") ON DELETE CASCADE,
+    CONSTRAINT "product_post_link_link_fk" FOREIGN KEY ("link_id") REFERENCES "product_link"("id") ON DELETE CASCADE
+);

--- a/src/test/java/net/detalk/api/service/ProductPostServiceTest.java
+++ b/src/test/java/net/detalk/api/service/ProductPostServiceTest.java
@@ -27,6 +27,7 @@ import net.detalk.api.mock.FakeUUIDGenerator;
 import net.detalk.api.repository.ProductLinkRepository;
 import net.detalk.api.repository.ProductMakerRepository;
 import net.detalk.api.repository.ProductPostLastSnapshotRepository;
+import net.detalk.api.repository.ProductPostLinkRepository;
 import net.detalk.api.repository.ProductPostRepository;
 import net.detalk.api.repository.ProductPostSnapshotAttachmentFileRepository;
 import net.detalk.api.repository.ProductPostSnapshotRepository;
@@ -70,6 +71,8 @@ class ProductPostServiceTest {
     private ProductPostSnapshotTagRepository postSnapshotTagRepository;
     @Mock
     private ProductPostSnapshotRepository postSnapshotRepository;
+    @Mock
+    private ProductPostLinkRepository productPostLinkRepository;
     @Mock
     private TagService tagService;
     @Mock
@@ -122,6 +125,7 @@ class ProductPostServiceTest {
             tagService,
             postSnapshotTagRepository,
             postSnapshotRepository,
+            productPostLinkRepository,
             timeHolder,
             uuidGenerator
         );


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
	- 제품 포스트와 링크 간의 관계를 관리하는 새로운 데이터베이스 테이블 추가
	- 제품 포스트 링크를 생성하고 저장하는 새로운 기능 구현

- **기술적 개선**
	- 제품 포스트 및 링크 관리를 위한 새로운 리포지토리와 서비스 로직 도입
	- 데이터베이스 마이그레이션 스크립트를 통한 스키마 업데이트

- **테스트**
	- 새로운 기능에 대한 테스트 환경 준비

<!-- end of auto-generated comment: release notes by coderabbit.ai -->