### PR TITLE
AccessToken검증 Header에서 Cookie로 변경

### DIFF
--- a/src/main/java/net/detalk/api/support/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/net/detalk/api/support/filter/JwtAuthenticationFilter.java
@@ -2,6 +2,7 @@ package net.detalk.api.support.filter;
 
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
+import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
@@ -30,6 +31,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     private final JwtTokenProvider jwtTokenProvider;
     private final JwtConstants jwtConstants;
+    private final static String ACCESS_TOKEN = "accessToken";
 
     @Override
     protected void doFilterInternal(
@@ -62,9 +64,22 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     }
 
     private String resolveToken(HttpServletRequest request) {
-        String bearerToken = request.getHeader("Authorization");
-        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith("Bearer ")) {
-            return bearerToken.substring(7);
+        Cookie[] cookies = request.getCookies();
+
+        // 쿠키 자체가 빈 값
+        if (cookies == null) {
+            return null;
+        }
+
+        for(Cookie cookie : cookies) {
+            if (ACCESS_TOKEN.equals(cookie.getName())) {
+                String token = cookie.getValue();
+                if (StringUtils.hasText(token)) {
+                    return token;
+                }
+                // 토큰은 있지만 토큰이 빈값일경우
+                return null;
+            }
         }
         return null;
     }

--- a/src/main/java/net/detalk/api/support/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/net/detalk/api/support/filter/JwtAuthenticationFilter.java
@@ -72,14 +72,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         }
 
         for(Cookie cookie : cookies) {
-            if (ACCESS_TOKEN.equals(cookie.getName())) {
-                String token = cookie.getValue();
-                if (StringUtils.hasText(token)) {
-                    return token;
-                }
-                // 토큰은 있지만 토큰이 빈값일경우
-                return null;
-            }
+            return StringUtils.hasText(cookie.getValue()) ? cookie.getValue() : null;
         }
         return null;
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **리팩토링**
	- 인증 토큰 검증 방식을 개선하여, 기존에는 HTTP 헤더에서 토큰을 확인하던 방식에서 쿠키 내 저장된 토큰을 활용하도록 변경되었습니다. 이로 인해 쿠키가 없거나 토큰 값이 비어있는 경우를 보다 명확하게 처리하며, 인증 과정의 안정성을 높였습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->