### PR TITLE
Jwt 쿠키 핸들링

### DIFF
--- a/src/main/java/net/detalk/api/auth/service/RefreshTokenService.java
+++ b/src/main/java/net/detalk/api/auth/service/RefreshTokenService.java
@@ -1,8 +1,10 @@
 package net.detalk.api.auth.service;
 
 import io.jsonwebtoken.Claims;
+
 import java.time.Instant;
 import java.util.List;
+
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import net.detalk.api.auth.controller.v2.response.JwtTokenResponse;
@@ -58,13 +60,13 @@ public class RefreshTokenService {
         String newAccessToken = tokenProvider.generateAccessToken(memberId,
             String.join(",", memberRoles));
 
-
         return new JwtTokenResponse(newAccessToken, newRefreshToken);
     }
 
 
     /**
      * 기존 리프레시 토큰 비활성화 후 새로 생성
+     *
      * @param memberId 사용자 ID
      * @return 생성된 리프레시 토큰
      */

--- a/src/main/java/net/detalk/api/support/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/net/detalk/api/support/filter/JwtAuthenticationFilter.java
@@ -39,7 +39,10 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     protected boolean shouldNotFilter(HttpServletRequest request) {
         String path = request.getServletPath();
 
-        if (jwtConstants.getRefreshPath().equals(path) || path.equals("/api/health")) {
+        String healthCheckPath = "/api/health";
+        String refreshPath = jwtConstants.getRefreshPath() + "/refresh";
+
+        if (refreshPath.equals(path) || healthCheckPath.equals(path)) {
             return true;
         }
 

--- a/src/main/java/net/detalk/api/support/security/SecurityExceptionHandlerConfig.java
+++ b/src/main/java/net/detalk/api/support/security/SecurityExceptionHandlerConfig.java
@@ -6,6 +6,9 @@ import java.io.PrintWriter;
 import lombok.RequiredArgsConstructor;
 import net.detalk.api.support.error.ErrorCode;
 import net.detalk.api.support.error.ErrorMessage;
+import net.detalk.api.support.security.jwt.JwtConstants;
+import net.detalk.api.support.util.CookieUtil;
+import net.detalk.api.support.util.EnvironmentHolder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.MediaType;
@@ -29,6 +32,8 @@ import org.springframework.security.web.access.AccessDeniedHandler;
 public class SecurityExceptionHandlerConfig {
 
     private final ObjectMapper objectMapper;
+    private final JwtConstants jwtConstants;
+    private final EnvironmentHolder env;
 
     @Bean
     public AuthenticationEntryPoint unauthorizedHandler() {
@@ -36,6 +41,14 @@ public class SecurityExceptionHandlerConfig {
             response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
             response.setContentType(MediaType.APPLICATION_JSON_VALUE);
             response.setCharacterEncoding("UTF-8");
+
+            boolean secure = "prod".equals(env.getActiveProfile());
+
+            CookieUtil.deleteCookieWithPath(response, "refreshToken", jwtConstants.getRefreshPath(),
+                secure);
+            CookieUtil.deleteCookieWithPath(response, "accessToken", jwtConstants.getAccessPath(),
+                secure);
+
             PrintWriter writer = response.getWriter();
             writer.write(objectMapper.writeValueAsString(new ErrorMessage(ErrorCode.UNAUTHORIZED)));
             writer.flush();


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
  - 로그아웃 엔드포인트가 "/logout"에서 "/sign-out"으로 변경되어, 사용자 세션 종료 시 업데이트된 경로를 사용합니다.
  
- **버그 수정**
  - 토큰 갱신 시 발생할 수 있는 오류를 보다 안정적으로 처리하여, 갱신 성공 시에는 안전한 쿠키 설정을, 오류 발생 시에는 쿠키 삭제가 확실히 수행되도록 개선하였습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->