### PR TITLE
통계 데이터 - 국가별 클릭 횟수

### DIFF
--- a/src/main/java/net/detalk/api/link/controller/v1/ShortLinkController.java
+++ b/src/main/java/net/detalk/api/link/controller/v1/ShortLinkController.java
@@ -54,6 +54,8 @@ public class ShortLinkController {
 
     /**
      * 국가별 통계 조회
+     * @param shortCode 단축 URL
+     * @return 국가별 클릭 통계 정보
      */
     @GetMapping("/{shortCode}/stats/by-country")
     public ResponseEntity<ShortLinkCountryStatsResponse> getShortLinkCountryStats(

--- a/src/main/java/net/detalk/api/link/controller/v1/ShortLinkController.java
+++ b/src/main/java/net/detalk/api/link/controller/v1/ShortLinkController.java
@@ -1,9 +1,12 @@
 package net.detalk.api.link.controller.v1;
 
 import jakarta.servlet.http.HttpServletRequest;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import net.detalk.api.link.domain.CountryStatPoint;
 import net.detalk.api.link.controller.v1.response.ResolveShortLinkResponse;
+import net.detalk.api.link.controller.v1.response.ShortLinkCountryStatsResponse;
 import net.detalk.api.link.service.ShortLinkService;
 import net.detalk.api.support.util.ClientInfoUtils;
 import net.detalk.api.support.util.ClientInfoUtils.ClientAgentInfo;
@@ -25,6 +28,12 @@ public class ShortLinkController {
     private final ShortLinkService shortLinkService;
     private final ClientInfoUtils clientInfoUtils;
 
+    /**
+     * 단축 URL 통계 저장
+     * @param shortCode 단축 URL
+     * @param servlet 클라이언트 정보
+     * @return 단축 URL의 원본 URL
+     */
     @GetMapping("/{shortCode}")
     public ResponseEntity<ResolveShortLinkResponse> resolveShortLink(
         @PathVariable("shortCode") String shortCode,
@@ -41,6 +50,20 @@ public class ShortLinkController {
         ResolveShortLinkResponse responseBody = new ResolveShortLinkResponse(originalUrl);
 
         return ResponseEntity.ok().body(responseBody);
+    }
+
+    /**
+     * 국가별 통계 조회
+     */
+    @GetMapping("/{shortCode}/stats/by-country")
+    public ResponseEntity<ShortLinkCountryStatsResponse> getShortLinkCountryStats(
+        @PathVariable("shortCode") String shortCode) {
+        List<CountryStatPoint> countryStats = shortLinkService.getClickStatsByCountry(shortCode);
+
+        ShortLinkCountryStatsResponse responseBody = new ShortLinkCountryStatsResponse(
+            countryStats);
+
+        return ResponseEntity.ok(responseBody);
     }
 
 }

--- a/src/main/java/net/detalk/api/link/controller/v1/response/ShortLinkCountryStatsResponse.java
+++ b/src/main/java/net/detalk/api/link/controller/v1/response/ShortLinkCountryStatsResponse.java
@@ -1,0 +1,8 @@
+package net.detalk.api.link.controller.v1.response;
+
+import java.util.List;
+import net.detalk.api.link.domain.CountryStatPoint;
+
+public record ShortLinkCountryStatsResponse(List<CountryStatPoint> stats) {
+
+}

--- a/src/main/java/net/detalk/api/link/domain/CountryStatPoint.java
+++ b/src/main/java/net/detalk/api/link/domain/CountryStatPoint.java
@@ -1,5 +1,18 @@
 package net.detalk.api.link.domain;
 
 //  국가별 통계 (국가명, 클릭 수)
-public record CountryStatPoint(String country, long count) {}
+public record CountryStatPoint(String country, long count) {
+
+    // new CountryStatPoint(...) 가 호출될 때마다 실행됨
+    public CountryStatPoint {
+        if (country == null || country.isBlank()) {
+            throw new IllegalArgumentException("country must not be null");
+        }
+
+        if (count < 0) {
+            throw new IllegalArgumentException("count must not be negative");
+        }
+    }
+
+}
 

--- a/src/main/java/net/detalk/api/link/domain/CountryStatPoint.java
+++ b/src/main/java/net/detalk/api/link/domain/CountryStatPoint.java
@@ -1,0 +1,5 @@
+package net.detalk.api.link.domain;
+
+//  국가별 통계 (국가명, 클릭 수)
+public record CountryStatPoint(String country, long count) {}
+

--- a/src/main/java/net/detalk/api/link/repository/ShortLinkLogRepository.java
+++ b/src/main/java/net/detalk/api/link/repository/ShortLinkLogRepository.java
@@ -1,7 +1,18 @@
 package net.detalk.api.link.repository;
 
+import java.util.List;
+import net.detalk.api.link.domain.CountryStatPoint;
 import net.detalk.api.link.domain.ShortLinkLog;
 
 public interface ShortLinkLogRepository {
     ShortLinkLog save(ShortLinkLog logEntry);
+
+    /**
+     * 지정된 링크 ID(linkId)에 대한 국가별 클릭 수를 조회합니다.
+     *
+     * @param linkId 통계를 조회할 short_links 테이블의 ID
+     * @return 국가명과 클릭 수를 담은 CountryStatPoint 리스트
+     */
+    List<CountryStatPoint> getClickCountsByLinkId(long linkId);
+
 }

--- a/src/main/java/net/detalk/api/link/repository/ShortLinkLogRepositoryImpl.java
+++ b/src/main/java/net/detalk/api/link/repository/ShortLinkLogRepositoryImpl.java
@@ -2,9 +2,12 @@ package net.detalk.api.link.repository;
 
 import static net.detalk.jooq.tables.JShortLinksLogs.SHORT_LINKS_LOGS;
 
+import java.util.List;
 import lombok.RequiredArgsConstructor;
+import net.detalk.api.link.domain.CountryStatPoint;
 import net.detalk.api.link.domain.ShortLinkLog;
 import org.jooq.DSLContext;
+import org.jooq.impl.DSL;
 import org.springframework.stereotype.Repository;
 
 @RequiredArgsConstructor
@@ -29,4 +32,27 @@ public class ShortLinkLogRepositoryImpl implements ShortLinkLogRepository {
             .returning()
             .fetchOneInto(ShortLinkLog.class);
     }
+
+    @Override
+    public List<CountryStatPoint> getClickCountsByLinkId(long linkId) {
+
+        // todo : 현재는 count 함수를 이용하지만, 성능을 위해 따로 count 컬럼을 추가해야할수도?
+        var clickCount = DSL.count().as("click_count");
+        var countryName = DSL.coalesce(SHORT_LINKS_LOGS.COUNTRY, "Unknown").as("country_name");
+
+        var result = dsl.select(
+                countryName,
+                clickCount
+            )
+            .from(SHORT_LINKS_LOGS)
+            .where(SHORT_LINKS_LOGS.LINK_ID.eq(linkId))
+            .groupBy(countryName)
+            .fetch();
+
+        return result.map(record -> new CountryStatPoint(
+            record.value1(),
+            record.value2().longValue()
+        ));
+    }
+
 }

--- a/src/main/java/net/detalk/api/link/repository/ShortLinkRepository.java
+++ b/src/main/java/net/detalk/api/link/repository/ShortLinkRepository.java
@@ -8,4 +8,5 @@ public interface ShortLinkRepository {
     ShortLink save(String shortCode, String originalUrl, Long creatorId, Instant createdAt);
     Optional<String> findOriginalUrlByShortCode(String shortCode);
     Optional<ShortLink> findByShortCode(String shortCode);
+    Optional<Long> findIdByShortCode(String shortCode);
 }

--- a/src/main/java/net/detalk/api/link/repository/ShortLinkRepositoryImpl.java
+++ b/src/main/java/net/detalk/api/link/repository/ShortLinkRepositoryImpl.java
@@ -40,4 +40,13 @@ public class ShortLinkRepositoryImpl implements ShortLinkRepository{
             .where(SHORT_LINKS.SHORT_CODE.eq(shortCode))
             .fetchOptionalInto(ShortLink.class);
     }
+
+    @Override
+    public Optional<Long> findIdByShortCode(String shortCode) {
+        return dsl.select(SHORT_LINKS.ID)
+            .from(SHORT_LINKS)
+            .where(SHORT_LINKS.SHORT_CODE.eq(shortCode))
+            .fetchOptional(SHORT_LINKS.ID);
+    }
+
 }

--- a/src/main/java/net/detalk/api/link/service/ShortLinkService.java
+++ b/src/main/java/net/detalk/api/link/service/ShortLinkService.java
@@ -1,5 +1,7 @@
 package net.detalk.api.link.service;
 
+import java.util.List;
+import net.detalk.api.link.domain.CountryStatPoint;
 import org.springframework.transaction.annotation.Transactional;
 import java.time.Instant;
 import lombok.RequiredArgsConstructor;
@@ -89,5 +91,18 @@ public class ShortLinkService {
         shortLinkLogRepository.save(shortLinkLog);
 
         return shortLink.getOriginalUrl();
+    }
+
+    /**
+     * 국가별 단축 URL 클릭 횟수 조회
+     * @param shortCode 단축 URL
+     * @return 국가별 클릭 횟수
+     */
+    public List<CountryStatPoint> getClickStatsByCountry(String shortCode) {
+
+        Long linkId = shortLinkRepository.findIdByShortCode(shortCode)
+            .orElseThrow(ShortLinkNotFoundException::new);
+
+        return shortLinkLogRepository.getClickCountsByLinkId(linkId);
     }
 }

--- a/src/main/java/net/detalk/api/link/service/ShortLinkService.java
+++ b/src/main/java/net/detalk/api/link/service/ShortLinkService.java
@@ -98,6 +98,7 @@ public class ShortLinkService {
      * @param shortCode 단축 URL
      * @return 국가별 클릭 횟수
      */
+    @Transactional(readOnly = true)
     public List<CountryStatPoint> getClickStatsByCountry(String shortCode) {
 
         Long linkId = shortLinkRepository.findIdByShortCode(shortCode)


### PR DESCRIPTION
#34 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새로운 기능**
  - 단축 링크의 국가별 클릭 통계를 조회할 수 있는 새 API 엔드포인트가 추가되었습니다.
  - 단축 링크 코드로 관련 링크 정보를 효율적으로 조회하여, 국가별 클릭 데이터를 기반으로 사용자 참여 분석이 강화되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->